### PR TITLE
docs: add npm install step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Available Scripts
 
-In the project directory, you can run:
+In the project directory, first install dependencies:
+
+### `npm install`
+
+Installs all required dependencies for the project, including `react-scripts`.
+
+Then you can run:
 
 ### `npm start`
 


### PR DESCRIPTION
## Summary
Adds an `npm install` step to the README before running `npm start`.

## Reason
New users who clone the repository may encounter the error:
`react-scripts: command not found` if dependencies are not installed first.

This update clarifies the setup process.

## Changes
- Added `npm install` instruction before running scripts

## Type of Change
- Documentation update (no code changes)